### PR TITLE
Aggregated Win Expectancy

### DIFF
--- a/data/commons/funciones/agg_grouping_id.sql
+++ b/data/commons/funciones/agg_grouping_id.sql
@@ -12,7 +12,8 @@ BEGIN
     /* Para probar esta funcion hacer: SELECT agg_grouping_id( 'majorLeagueId,seasonId'); */
 
     /* Si se necesita un nuevo campo de agracion, anyadirlo al inicio */
-    DECLARE all_grouping_fields VARCHAR(255) DEFAULT 'majorLeagueId,seasonId,gameType2,teamType,venueId,teamId,playerId';
+    DECLARE all_grouping_fields VARCHAR(255) DEFAULT 'battingTeamId,pitchingTeamId,inning,runnersBeforePlay,outsBeforePlay,majorLeagueId,seasonId,gameType2,teamType,venueId,teamId,playerId';
+
     DECLARE grouping_id VARCHAR(20) DEFAULT '';
     DECLARE gf VARCHAR(30);
 

--- a/data/commons/procedimientos/master_procedure.sql
+++ b/data/commons/procedimientos/master_procedure.sql
@@ -31,7 +31,9 @@ CALL rem_run_expectancy_matrix();
 CALL rem_event_run_value();
 
 -- Win Expectancy
-CALL we_win_expectancy();
+CALL we_win_expectancy( 'majorLeagueId,seasonId,gameType2', 'BATTING', 5);
+CALL we_win_expectancy( 'majorLeagueId,seasonId,inning,gameType2', 'BATTING', 5);
+CALL we_win_expectancy( 'majorLeagueId,seasonId,inning,gameType2,runnersBeforePlay,outsBeforePlay', 'BATTING', 5);
 
 -- Aggregated Batting Stats
 CALL agg_batting_stats('majorLeagueId,seasonId,gameType2');

--- a/data/win_expectancy/funciones/we_generate_score_clause.sql
+++ b/data/win_expectancy/funciones/we_generate_score_clause.sql
@@ -1,0 +1,41 @@
+USE baseball;
+
+DROP FUNCTION we_generate_score_clause;
+
+DELIMITER //
+
+CREATE FUNCTION we_generate_score_clause( p_perspective VARCHAR(30), p_score_difference INTEGER )
+RETURNS VARCHAR(500)
+DETERMINISTIC
+BEGIN
+
+    /* Para probar esta funcion Select we_generate_score_clause( 'PITCHING', 5 ); */
+
+    DECLARE clause VARCHAR(500);
+
+    CASE p_perspective
+    WHEN 'BATTING' THEN
+        SET clause = CONCAT(' CASE ',
+                            ' WHEN battingTeamScore - pitchingTeamScore <= ', -p_score_difference, ' THEN ', -p_score_difference,
+                            ' WHEN battingTeamScore - pitchingTeamScore >  ',  p_score_difference, ' THEN ',  p_score_difference,
+                            ' ELSE battingTeamScore - pitchingTeamScore',
+                            ' END score_difference, ',
+                            ' battingTeamScoreEndGame > pitchingTeamScoreEndGame wins, ',
+                            ' battingTeamScoreEndGame < pitchingTeamScoreEndGame losses '
+                        );
+    WHEN 'PITCHING' THEN
+        SET clause = CONCAT(' CASE ',
+                            ' WHEN pitchingTeamScore - battingTeamScore <= ', -p_score_difference, ' THEN ', -p_score_difference,
+                            ' WHEN pitchingTeamScore - battingTeamScore >  ',  p_score_difference, ' THEN ',  p_score_difference,
+                            ' ELSE pitchingTeamScore - battingTeamScore',
+                            ' END score_difference, ',
+                            ' pitchingTeamScoreEndGame > battingTeamScoreEndGame wins, ',
+                            ' pitchingTeamScoreEndGame < battingTeamScoreEndGame losses '
+                            );
+    END CASE;
+
+    RETURN clause;
+
+END //
+
+DELIMITER ;

--- a/data/win_expectancy/tablas/win_expectancy.sql
+++ b/data/win_expectancy/tablas/win_expectancy.sql
@@ -3,12 +3,23 @@ USE baseball;
 DROP TABLE we_win_expectancy;
 
 CREATE TABLE IF NOT EXISTS we_win_expectancy (
+  grouping_id INTEGER UNSIGNED,
+  grouping_description VARCHAR(255),
   majorLeagueId INTEGER,
   seasonId DOUBLE,
+  gameType2 VARCHAR(10),
+  venueId INTEGER,
+  battingTeamId INTEGER,
+  pitchingTeamId INTEGER,
+  inning INTEGER,
   runnersBeforePlay VARCHAR(3),
   outsBeforePlay INTEGER,
-  battingTeamScore INTEGER,
+  perspective VARCHAR(20),
+  score_difference INTEGER,
+  games INTEGER,
+  wins INTEGER,
+  losses INTEGER,
   win_expectancy DOUBLE
 );
 
-ALTER TABLE we_win_expectancy ADD INDEX(majorLeagueId, seasonId);
+ALTER TABLE we_win_expectancy ADD INDEX( grouping_id );


### PR DESCRIPTION
En este commit hacemos:
1. Una modifcacion al procedimiento de win_expectancy. de Ahora en adelante es capaz de calcular win_expectancy a distintos niveles ( ver tabla ).
2. Una funcion( we_generate_score_clause.sql ) que genera un case statement para obtener partidos ganados y perdidos desde la perspectiva del equipo lanzador o bateador.
3. Agregacion a campo dentro de la funcion agg_grouping_id para soportar los campos sobre los cuale se quiere calcular win_expectancy.